### PR TITLE
@ng-bootstrap/ng-bootstrap version 2.0.0 not supported in @angular 7.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/platform-browser": "7.2.0",
     "@angular/platform-browser-dynamic": "7.2.0",
     "@angular/router": "7.2.0",
-    "@ng-bootstrap/ng-bootstrap": "2.0.0",
+    "@ng-bootstrap/ng-bootstrap": "4.0.0",
     "bootstrap": "4.1.2",
     "core-js": "2.4.1",
     "jquery": "3.2.1",


### PR DESCRIPTION
Update @ng-bootstrap/ng-bootstrap version to 4.0.0.
version 2.0.0 not supported in @angular 7.x.x, this situation break build in production mode.